### PR TITLE
Added Heroku deployment configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
       install:
         - pip install -r requirements.txt
       script:
-        - python manage.py test
+        - DJANGO_SETTINGS_MODULE=backend.settings.production python manage.py test
     - stage: test
       language: node_js
       node_js:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3
+RUN apt-get -y install curl \
+  && curl -sL https://deb.nodesource.com/setup_14.x | bash \
+  && apt-get install nodejs \
+  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+  && apt-get update && apt-get install yarn
+WORKDIR /backend
+
+#Install python dependencies
+COPY ./backend /backend/
+RUN pip install -r requirements.txt
+
+#Install React dependencies
+WORKDIR /frontend
+
+COPY ./frontend /frontend/
+RUN yarn install && yarn build
+
+#Move all static files other than index.html to root/ for whitenoise
+WORKDIR /frontend/build
+
+RUN mkdir root && mv *.ico *.js *.json root
+
+#Collect all static files for Django
+RUN mkdir /backend/staticfiles
+
+WORKDIR /
+
+RUN DJANGO_SETTINGS_MODULE=backend.settings.production \
+    python backend/manage.py collectstatic --noinput
+
+EXPOSE $PORT
+
+CMD python backend/manage.py runserver 0.0.0.0:$PORT 

--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -13,19 +13,12 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
 
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = ')fn0bm*y%k_@^%k4ofkg01#c-8renvy_uts7lsb@m!z6d9g(8^'
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-ALLOWED_HOSTS = '*'
 CORS_ORIGIN_ALLOW_ALL = True
 
 # Application definition

--- a/backend/backend/settings/development.py
+++ b/backend/backend/settings/development.py
@@ -1,0 +1,9 @@
+from backend.settings.base import *
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = ')fn0bm*y%k_@^%k4ofkg01#c-8renvy_uts7lsb@m!z6d9g(8^'
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+ALLOWED_HOSTS = '*'

--- a/backend/backend/settings/production.py
+++ b/backend/backend/settings/production.py
@@ -1,0 +1,20 @@
+import os
+from backend.settings.base import *
+
+SECRET_KEY = 'averysecretkeythatonlyweknowof'
+DEBUG = False
+ALLOWED_HOSTS = ['*']
+
+INSTALLED_APPS.extend(["whitenoise.runserver_nostatic"])
+
+# Must insert after SecurityMiddleware, which is first in settings/common.py
+MIDDLEWARE.insert(1, "whitenoise.middleware.WhiteNoiseMiddleware")
+
+TEMPLATES[0]["DIRS"] = [os.path.join(BASE_DIR, "../", "frontend", "build")]
+
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "../", "frontend", "build", "static")]
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
+
+STATIC_URL = "/static/"
+WHITENOISE_ROOT = os.path.join(BASE_DIR, "../", "frontend", "build", "root")

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -1,7 +1,9 @@
-from django.urls import path
+from django.urls import path, re_path
+from django.views.generic import TemplateView
 
 from . import views
 
 urlpatterns = [
     path(r'test/', views.index, name='index'),
+    re_path(".*", TemplateView.as_view(template_name="index.html"))
 ]

--- a/backend/backend/wsgi.py
+++ b/backend/backend/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings.base')
 
 application = get_wsgi_application()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,4 @@
 django-cors-headers==3.2.1
 django==3.0.6
+gunicorn==20.0.4
+whitenoise==5.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     volumes:
       - ./backend/:/backend # maps host diretory to internal container directory
     working_dir: /backend/
+    environment:
+      - DJANGO_SETTINGS_MODULE=backend.settings.development
     command: sh entrypoint.sh
   frontend:
     build: ./frontend

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+yarn
 yarn start

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,5 +29,9 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "engines":{
+    "node": "14.2.0",
+    "npm": "6.14.4"
+  }
 }

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: Dockerfile
+run:
+  web: python backend/manage.py runserver 0.0.0.0:$PORT


### PR DESCRIPTION
This is a feature commit that introduces the following :
1. Separates `settings.py` for `development` and `production`
2. Adds heroku continuous deployment configuration
3. Changes `travis` build to `production` with a check on Heroku to deploy only if Continuous Integration passes.  